### PR TITLE
fix api by making it simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ console.log(mobile());
 
 ## API
 
-### mobile([user-agent], [options])
+### mobile({ [ua], [tablet] })
 
-Returns true if a mobile browser is being used. If you don't specify
-`user-agent` it will use `navigator.userAgent`. To detect tablet, pass `{ tablet: true }` as `options` argument.
+Returns true if a mobile browser is being used.
 
-### mobile(request, [options])
+If you don't specify `opts.ua` it will use `navigator.userAgent`.
 
-Returns true if the given [node.js http request](http://nodejs.org/api/http.html#http_http_incomingmessage) comes with a mobile user agent header.
+To add support for tablets, set `tablet: true`.
+
+`opts.ua` can also be an instance of a [node.js http request](http://nodejs.org/api/http.html#http_http_incomingmessage), in which
+case it will reader the user agent header.
 
 Example:
 

--- a/index.js
+++ b/index.js
@@ -7,14 +7,14 @@ var mobileRE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|c
 
 var tabletRE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino|android|ipad|playbook|silk/i;
 
-function isMobile (ua, opts) {
-  if (!opts && ua !== null && typeof ua === 'object') opts = ua;
+function isMobile (opts) {
+  if (!opts) opts = {}
+  var ua = opts.ua
   if (!ua && typeof navigator !== 'undefined') ua = navigator.userAgent;
   if (ua && ua.headers && typeof ua.headers['user-agent'] === 'string') {
     ua = ua.headers['user-agent'];
   }
   if (typeof ua !== 'string') return false;
-  if (!opts) opts = {};
 
   return opts.tablet
     ? tabletRE.test(ua)

--- a/test.js
+++ b/test.js
@@ -7,16 +7,15 @@ var ffos = 'Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0';
 var ipad = 'Mozilla/5.0 (iPad; CPU OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13F69 Safari/601.1'
 
 test('is mobile', function (t) {
-  t.ok(isMobile(iphone));
-  t.ok(isMobile(ffos));
-  t.notOk(isMobile(ipad));
-  t.ok(isMobile(ipad, {tablet: true}));
-  t.ok(isMobile({ headers: { 'user-agent': iphone } }));
-  t.notOk(isMobile(chrome));
-  t.notOk(isMobile({ headers: { 'user-agent': chrome } }));
-  t.notOk(isMobile(null));
-  t.notOk(isMobile({ headers: null }));
-  t.notOk(isMobile({ headers: { 'user-agent': null } }));
+  t.ok(isMobile({ ua: iphone }));
+  t.ok(isMobile({ ua: ffos }));
+  t.notOk(isMobile({ ua: ipad }));
+  t.ok(isMobile({ ua: ipad, tablet: true }));
+  t.ok(isMobile({ ua: { headers: { 'user-agent': iphone } } }));
+  t.notOk(isMobile({ ua: chrome }));
+  t.notOk(isMobile({ ua: { headers: { 'user-agent': chrome } } }));
+  t.notOk(isMobile());
+  t.notOk(isMobile({ ua: { headers: null } }));
+  t.notOk(isMobile({ ua: { headers: { 'user-agent': null } } }));
   t.end();
 });
-

--- a/test.js
+++ b/test.js
@@ -17,5 +17,20 @@ test('is mobile', function (t) {
   t.notOk(isMobile());
   t.notOk(isMobile({ ua: { headers: null } }));
   t.notOk(isMobile({ ua: { headers: { 'user-agent': null } } }));
+
+  global.navigator = {};
+
+  global.navigator.userAgent = iphone;
+  t.ok(isMobile());
+  t.ok(isMobile({ tablet: true }));
+
+  global.navigator.userAgent = chrome;
+  t.notOk(isMobile());
+  t.notOk(isMobile({ tablet: true }));
+
+  global.navigator.userAgent = ipad;
+  t.notOk(isMobile());
+  t.ok(isMobile({ tablet: true }));
+
   t.end();
 });


### PR DESCRIPTION
@dy we were trying to be too smart here, we should really only have one options object.

Differentiating between

```js
isMobile({ tablet: true })
```

and

```js
isMobile({ headers: { ... } })
```

is bad api design.

I hope this fixes your issues for gl-plot3d