### PR TITLE
ESM support and typings fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,17 @@
-export declare function isMobile(ua?: string|object, opts?: object): boolean;
+interface HttpRequestHeadersInterfaceMock {
+    [id: string]: string | string[]
+}
+
+interface HttpRequestInterfaceMock {
+    headers: HttpRequestHeadersInterfaceMock,
+
+    [id: string]: any,
+}
+
+export interface IsMobileOptions
+{
+    ua?: string | HttpRequestInterfaceMock
+    tablet?: boolean
+}
+
+export declare function isMobile(opts?:IsMobileOptions): boolean;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = isMobile
 module.exports.isMobile = isMobile
+module.exports.default = isMobile
 
 var mobileRE = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series[46]0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "homepage": "https://github.com/juliangruber/is-mobile",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "prettier-standard '**/*.js' && standard && tape test.js"
   },


### PR DESCRIPTION
As a recreation of #13 

* Added supportd of ES modules (isMobile is exported as default)  
This will allow to write 
  ```javascript
  import isBrowser from "is-browser";
  ```
  instead of 
  ```javascript
  import  *  as isBrowser from "is-browser";
  ```
* Actualized `index.d.ts` for TS users code assitance