### PR TITLE
Add default export to TS definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,3 +16,4 @@ export interface IsMobileOptions
 }
 
 export declare function isMobile(opts?:IsMobileOptions): boolean;
+export default isMobile;


### PR DESCRIPTION
The TypeScript definition was missing the default export of the module so this adds it.