### PR TITLE
fix: add support for Redmi mobile

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = isMobile
 module.exports.isMobile = isMobile
 module.exports.default = isMobile
 
-const mobileRE = /(android|bb\d+|meego).+mobile|armv7l|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series[46]0|samsungbrowser.*mobile|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i
+const mobileRE = /(android|bb\d+|meego).+mobile|armv7l|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|redmi|series[46]0|samsungbrowser.*mobile|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i
 const notMobileRE = /CrOS/
 
 const tabletRE = /android|ipad|playbook|silk/i

--- a/test.js
+++ b/test.js
@@ -22,6 +22,8 @@ const samsungMobile =
   'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/16.0 Chrome/92.0.4515.166 Mobile Safari/537.36'
 const chromeOS =
   'Mozilla/5.0 (X11; CrOS armv7l 12105.100.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.144 Safari/537.36'
+const redmiMobile =
+  'HashKey/1.20.0 (Redmi K30; Android ) Language/zh Theme/light ScreenWidth/392 ScreenHeight/856'
 
 test('is mobile', function () {
   assert(isMobile({ ua: iphone }))
@@ -36,6 +38,7 @@ test('is mobile', function () {
   assert(!isMobile({ ua: { headers: { 'user-agent': null } } }))
   assert(!isMobile({ ua: samsung }))
   assert(isMobile({ ua: samsungMobile }))
+  assert(isMobile({ ua: redmiMobile }))
   assert(!isMobile(chromeOS))
   assert(!isMobile(chromeOS, { tablet: true }))
 


### PR DESCRIPTION
## Disclaimer 

Hello! I've been using your library for long time and wanna to say thank you so much!

## Background

I've found out that some redmi mobile devices were detected as not-mobile devices
(e.g. `HashKey/1.20.0 (Redmi K30; Android ) Language/zh Theme/light ScreenWidth/392 ScreenHeight/856`)

## Description

In this PR I've added support for Redmi mobile devices