### PR TITLE
Fix type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,12 +8,19 @@ interface HttpRequestInterfaceMock {
     [id: string]: any,
 }
 
-export interface IsMobileOptions
-{
-    ua?: string | HttpRequestInterfaceMock
-    tablet?: boolean
-    featureDetect?: boolean
+declare function isMobile(opts?: isMobile.IsMobileOptions): boolean;
+
+declare namespace isMobile{
+    export interface IsMobileOptions {
+        ua?: string | HttpRequestInterfaceMock
+        tablet?: boolean
+        featureDetect?: boolean
+    }
+
+    export {
+        isMobile,
+        isMobile as default
+    }
 }
 
-export declare function isMobile(opts?:IsMobileOptions): boolean;
-export default isMobile;
+export = isMobile


### PR DESCRIPTION
The correct way to type `module.exports`, is to use the `export =` syntax. More members, including types and values, can be exported using a namespace.